### PR TITLE
Added basic netCDF library support

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -169,7 +169,7 @@
 #cmakedefine HAVE_YN 1
 
 /* Define if you have the netcdf library (-lnetcdf).  */
-/* #undef HAVE_NETCDF */
+#cmakedefine HAVE_NETCDF 1
 
 /* Define if you have the mfhdf library (-lmfhdf).  */
 /* #undef HAVE_MFHDF */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,11 +5,18 @@ include_directories(${X11_Xmu_INCLUDE_DIR})
 include_directories(${X11_Xpm_INCLUDE_DIR})
 include_directories(${X11_Xt_INCLUDE_DIR})
 
+find_path(NETCDF_INCLUDE_DIR netcdf.h
+          PATHS ${NETCDF_INCLUDE} /ops/tools/include /usr/local/include )
+find_library(NETCDF_LIBRARIES NAMES netcdf libnetcdf
+             PATHS ${NETCDF_LIB} /ops/tools/lib /usr/local/lib )
+include_directories(${NETCDF_INCLUDE_DIR})
+
 set(LINKLIBS ${LINKLIBS} ${MOTIF_LIBRARIES})
 set(LINKLIBS ${LINKLIBS} ${X11_Xpm_LIB})
 set(LINKLIBS ${LINKLIBS} ${X11_Xmu_LIB})
 set(LINKLIBS ${LINKLIBS} ${X11_Xt_LIB})
 set(LINKLIBS ${LINKLIBS} ${X11_LIBRARIES})
+set(LINKLIBS ${LINKLIBS} ${NETCDF_LIBRARIES})
 
 file(GLOB OBJS "${CMAKE_CURRENT_SOURCE_DIR}/*.c")
 add_executable(xmgr ${OBJS})


### PR DESCRIPTION
Hi M.Lund:  Thank you so much for pulling xmgr into the 64 bit world.  I support one user who cannot live without it and I've been struggling to keep supporting xmgr for years.  We need netCDF, so here is a commit with minimal netCDF support.  I'm new to cmake, so please let me know if this makes sense and consider adding it to your branch.

Thanks much!

--Doug Hunt
